### PR TITLE
Reverb example additions

### DIFF
--- a/patch_sm/ReverbExample/ReverbExample.cpp
+++ b/patch_sm/ReverbExample/ReverbExample.cpp
@@ -4,9 +4,24 @@
 using namespace daisy;
 using namespace daisysp;
 using namespace patch_sm;
+using namespace std;
 
 DaisyPatchSM patch;
 ReverbSc     reverb;
+Switch       toggle;
+Switch       button;
+
+struct envStruct
+{
+    AdEnv     env;
+    float     envSig;
+    bool      DuckingEnabled;
+};
+
+envStruct     envelope;
+
+int counters[2] = {0, 0 };
+int divisions[2] = {2, 3 };
 
 void AudioCallback(AudioHandle::InputBuffer  in,
                    AudioHandle::OutputBuffer out,
@@ -52,15 +67,135 @@ void AudioCallback(AudioHandle::InputBuffer  in,
 
         float wetl, wetr;
         reverb.Process(sendl, sendr, &wetl, &wetr);
-        OUT_L[i] = dryl + wetl;
-        OUT_R[i] = dryr + wetr;
+
+        if (envelope.DuckingEnabled)
+        {
+            envelope.envSig = envelope.env.Process();
+            OUT_L[i] = (dryl + wetl) * envelope.envSig;
+            OUT_R[i] = (dryr + wetr) * envelope.envSig;
+        }
+        else
+        {
+            OUT_L[i] = (dryl + wetl);
+            OUT_R[i] = (dryr + wetr);
+        }
     }
 }
 
-int main(void)
+void InitEnvelope(float samplerate)
+{
+    envelope.DuckingEnabled = true;
+    envelope.envSig = 0.f;
+    //envelope values and Init
+    envelope.env.Init(samplerate);
+    envelope.env.SetMax(0.f);
+    envelope.env.SetMin(1.f);
+    envelope.env.SetCurve(2.f);
+    envelope.env.SetTime(ADENV_SEG_ATTACK, 0.015f);
+    envelope.env.SetTime(ADENV_SEG_DECAY, 0.5f);
+}
+
+int GetOutputState(int counter, int state)
+{
+    if (counter == 0)
+    {
+        return state;
+    }
+    return 0;
+}
+
+int main()
 {
     patch.Init();
     reverb.Init(patch.AudioSampleRate());
+    InitEnvelope(patch.AudioSampleRate());
+    button.Init(daisy::patch_sm::DaisyPatchSM::B7);
+    toggle.Init(daisy::patch_sm::DaisyPatchSM::B8);
     patch.StartAudio(AudioCallback);
-    while(1) {}
+    while(1) {
+
+        /** Read from CV_4 (-1, 1) and scale to (0.00001, 0.1) */
+        float env_decay = fmap(
+            patch.GetAdcValue(CV_4),
+            .005f,
+            0.5f,
+            Mapping::LINEAR);
+        envelope.env.SetTime(ADENV_SEG_DECAY, env_decay);
+
+        /** Debounce the switches */
+        toggle.Debounce();
+        button.Debounce();
+
+        /** Turn ducking on/off */
+        if (button.RisingEdge())
+        {
+            if (envelope.DuckingEnabled)
+            {
+                envelope.DuckingEnabled = false;
+            }
+            if (not envelope.DuckingEnabled)
+            {
+                envelope.DuckingEnabled = true;
+            }
+        }
+
+        /** Get the current toggle state and relevant clock divisions */
+        bool toggle_state = toggle.Pressed();
+        if (toggle_state)
+        {
+            divisions[0] = 2;
+            divisions[1] = 3;
+//            envelope.DuckingEnabled = true;
+        }
+        else
+        {
+            divisions[0] = 4;
+            divisions[1] = 6;
+//            envelope.DuckingEnabled = false;
+        }
+
+        /** Get the current gate in state */
+        bool state1 = patch.gate_in_1.State();
+        bool state2 = patch.gate_in_2.State();
+
+        /** Advance counters */
+        if (patch.gate_in_1.Trig())
+        {
+            counters[0] += 1;
+            counters[0] = counters[0] % divisions[0];
+            if (envelope.DuckingEnabled)
+            {
+                envelope.env.Trigger();
+            }
+        }
+        if (patch.gate_in_2.Trig())
+        {
+            counters[1] += 1;
+            counters[1] = counters[1] % divisions[1];
+        }
+
+        /** Get the current gate out state based on the counters */
+        int OutputState1 = GetOutputState(counters[0], state1);
+        int OutputState2 = GetOutputState(counters[1], state2);
+        int JointOutputState = std::max(OutputState1, OutputState2);
+        float led_voltage = JointOutputState * 5.0f;
+        if (OutputState1 > 0 and  !envelope.DuckingEnabled)
+        {
+            patch.WriteCvOut(
+                CV_OUT_1,
+                patch.GetRandomFloat(0.0, 5.0)
+                );
+        }
+        if (envelope.DuckingEnabled)
+        {
+            patch.WriteCvOut(
+                CV_OUT_1,
+                envelope.envSig
+            );
+        }
+        /** Send CV out */
+        dsy_gpio_write(&patch.gate_out_1, OutputState1);
+        dsy_gpio_write(&patch.gate_out_2, OutputState2);
+        patch.WriteCvOut(CV_OUT_2, led_voltage);
+    }
 }


### PR DESCRIPTION
This PR adds some random features to the patch.init():
- variable clock division on the gate in/outs (gate 1 will do 1/2 or 1/4, gate 2 will do 1/3 or 1/6). Division selectable on the toggle switch
- Sidechain ducking on the audio out using an AD envelope triggered by gate in 1. This envelope is sent out of the CV out if the ducking is enabled
- if ducking is not enabled, Random voltages are created on the trigger to gate in 1 and sent out via the CV out

Ducking should be toggled using the button but at the moment that is not working. This will be fixed in another PR #2 